### PR TITLE
Fair-2913: Worked example for create/update cycle of datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,31 @@ Examples:
 
 Outputs are in JSON format, but can be easily converted to CSV if needed using a tool like [`jq`](https://stedolan.github.io/jq/).
 
+## Create and Update Cycle for Datasets
+
+Generally the create and update cycle in FAIR works as follows. This is the same process used in the FAIR UI:
+
+1. Create a dataset based on intial JSON structure.
+2. Change the JSON in some way (this could include edited fields, new dictionaries, or deleted dictionaries).
+3. GET the latest version of the dataset.
+4. Work out the differences between the old and new data.
+5. PATCH the differences to the dataset endpoint.
+
+### How to Update a Dataset
+
+To demonstrate how these calls should look, the `fair-api-datasets-create.py` and `fair-api-datasets-update.py` helper commands can be used:
+
+- Start by creating a dataset based on a JSON structure we will call `dataset.json`. Use the schema specified in the API docs:
+```
+python3 fair-api-datasets-create.py ~/project/scratch/helper_post_patch/dataset.json
+```
+- Make a change to `dataset.json`, for example, add or remove a dictionary, or change some catalogue fields.
+- Call the `fair-api-datasets-update.py` command with `--dry-run` enabled. This will calculate differences print the appropriate PATCH call that should be used to make the dataset consistent with `dataset.json`. Running witout --dry-run will apply the change to the database:
+```
+python3 fair-api-datasets-update.py ~/project/scratch/helper_post_patch/dataset.json --dry-run
+```
+- Repeat steps 2-3 to make further updates.
+
 ## Converting JSON output to CSV
 
 JSON data can be converted to CSV with a tool like `jq`. For example, to select data and then convert it to CSV with headers, the following script will first select data to a file, then convert it to the target format:
@@ -339,5 +364,3 @@ python fair-api-datasets-delete.py <dataset_code>
 Please contact Aridhia Informatics to license this code. 
 
 Copyright - All rights reserved (c) 2020 Aridhia Informatics.
-
-

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ To demonstrate how to update a dataset, the `fair-api-datasets-update.py` helper
 2. Make a change to the metadata in `dataset.json`, for example, add or remove a dictionary from the `dictionaries` list, or change some values in the `catalogue` attributes.
 3. Now call the `fair-api-datasets-update.py` command with `--dry-run` enabled. This will calculate differences and print the appropriate PATCH call that should be used to update the dataset. Running witout --dry-run will apply the change to the database:
 ```
-python3 fair-api-datasets-update.py ~/project/scratch/helper_post_patch/dataset.json --dry-run
+python fair-api-datasets-update.py ~/project/scratch/helper_post_patch/dataset.json --dry-run
 ```
 - Repeat steps 2-3 to make further updates to the dataset.
 

--- a/README.md
+++ b/README.md
@@ -287,30 +287,19 @@ Examples:
 
 Outputs are in JSON format, but can be easily converted to CSV if needed using a tool like [`jq`](https://stedolan.github.io/jq/).
 
-## Create and Update Cycle for Datasets
+## Updating a Dataset Entry (API)
 
-Generally the create and update cycle in FAIR works as follows. This is the same process used in the FAIR UI:
+This section describes how the update cycle in FAIR works.
 
-1. Create a dataset based on intial JSON structure.
-2. Change the JSON in some way (this could include edited fields, new dictionaries, or deleted dictionaries).
-3. GET the latest version of the dataset.
-4. Work out the differences between the old and new data.
-5. PATCH the differences to the dataset endpoint.
+To demonstrate how to update a dataset, the `fair-api-datasets-update.py` helper command can be used:
 
-### How to Update a Dataset
-
-To demonstrate how these calls should look, the `fair-api-datasets-create.py` and `fair-api-datasets-update.py` helper commands can be used:
-
-- Start by creating a dataset based on a JSON structure we will call `dataset.json`. Use the schema specified in the API docs:
-```
-python3 fair-api-datasets-create.py ~/project/scratch/helper_post_patch/dataset.json
-```
-- Make a change to `dataset.json`, for example, add or remove a dictionary, or change some catalogue fields.
-- Call the `fair-api-datasets-update.py` command with `--dry-run` enabled. This will calculate differences print the appropriate PATCH call that should be used to make the dataset consistent with `dataset.json`. Running witout --dry-run will apply the change to the database:
+1. Start by creating a JSON file conforming to the metadata specification set out in [Create a Dataset Entry](#). We will call this `dataset.json`. Post this to the API and make a note of the dataset_code.
+2. Make a change to the metadata in `dataset.json`, for example, add or remove a dictionary from the `dictionaries` list, or change some values in the `catalogue` attributes.
+3. Now call the `fair-api-datasets-update.py` command with `--dry-run` enabled. This will calculate differences and print the appropriate PATCH call that should be used to update the dataset. Running witout --dry-run will apply the change to the database:
 ```
 python3 fair-api-datasets-update.py ~/project/scratch/helper_post_patch/dataset.json --dry-run
 ```
-- Repeat steps 2-3 to make further updates.
+- Repeat steps 2-3 to make further updates to the dataset.
 
 ## Converting JSON output to CSV
 

--- a/datasets/command_base.py
+++ b/datasets/command_base.py
@@ -1,0 +1,45 @@
+import requests
+import os
+import json
+import sys
+from datasets.diff_helper import DiffHelper
+
+if 'FAIR_API_TOKEN' not in os.environ:
+    print('Please add FAIR_API_TOKEN to the environment')
+    exit(1)
+
+if 'FAIR_API_ENDPOINT' not in os.environ:
+    print('Please add FAIR_API_ENDPOINT to the environment')
+    exit(1)
+
+DRY_RUN = True if (len(sys.argv) > 2 and sys.argv[2] == '--dry-run') else False
+
+if len(sys.argv) < 2:
+    print(f'Usage: {sys.argv[0]} <path to dataset definition json file> <--dry-run>')
+    exit(1)
+    
+FAIR_API_TOKEN=os.environ['FAIR_API_TOKEN']
+FAIR_API_ENDPOINT=os.environ['FAIR_API_ENDPOINT']
+https = 'https://'
+
+if FAIR_API_ENDPOINT[:5] == 'https':
+    https = ''
+
+dataset_list_endpoint = f'{https}{FAIR_API_ENDPOINT}datasets'
+FAIR_URL = f'{https}{FAIR_API_ENDPOINT}'[:-4]
+
+headers = {
+    'Authorization': f'Bearer {FAIR_API_TOKEN}',
+    'Content-Type' : 'application/json'
+}
+
+def definition_file():
+    definition_file = sys.argv[1]
+    if not os.path.isfile(definition_file):
+        print(f'Definition file not valid: {definition_file}')
+        exit(1)
+    return definition_file
+
+def dataset_url(code=None):
+  if code: return f'{https}{FAIR_API_ENDPOINT}datasets/{code}/'
+  return f'{https}{FAIR_API_ENDPOINT}datasets/'

--- a/datasets/command_base.py
+++ b/datasets/command_base.py
@@ -12,7 +12,7 @@ if 'FAIR_API_ENDPOINT' not in os.environ:
     print('Please add FAIR_API_ENDPOINT to the environment')
     exit(1)
 
-DRY_RUN = True if (len(sys.argv) > 2 and sys.argv[2] == '--dry-run') else False
+DRY_RUN = len(sys.argv) > 2 and sys.argv[2] == '--dry-run'
 
 if len(sys.argv) < 2:
     print(f'Usage: {sys.argv[0]} <path to dataset definition json file> <--dry-run>')

--- a/datasets/diff_helper.py
+++ b/datasets/diff_helper.py
@@ -1,0 +1,115 @@
+import requests
+import os
+import json
+import sys
+
+CATALOGUE_FIELDS = [
+  'description',
+  'creator',
+  'contactPoint',
+  'publisher',
+  'license',
+  'versionInfo',
+  'keyword',
+  'identifier',
+  'rights',
+]
+
+DICTIONARY_FIELDS = [
+  'name',
+  'code',
+  'description',
+  'fields',
+  'lookups'
+]
+
+class DiffHelper:
+  def catalogue_diff(previous, current):
+    diff = {}
+    for field in CATALOGUE_FIELDS:
+      if (field in current and previous[field] != current[field]): diff[field] = current[field]
+    return diff
+
+  def dictionaries_diff(previous, current):
+    diff = {}
+    codes, dictionaries = DiffHelper.new_and_deleted_dictionaries(previous, current)
+    dictionaries += DiffHelper.changed_dictionaries(current, previous, codes)
+    return dictionaries
+
+  def dataset_diff(original, data):
+    diff = {}
+
+    if DiffHelper.is_equal(original, data): return diff
+    
+    if 'name' in data and original['name'] != data['name']:
+      diff['name'] = data['name']
+    
+    catalogueUpdates = DiffHelper.catalogue_diff(original['catalogue'], data['catalogue'])
+    dictionaryUpdates = DiffHelper.dictionaries_diff(original['dictionaries'], data['dictionaries'])
+    if catalogueUpdates: diff['catalogue'] = catalogueUpdates
+    if dictionaryUpdates: diff['dictionaries'] = dictionaryUpdates
+
+    return diff
+
+  def sanitize_dict(original):
+    modified = original.copy()
+    for key in original:
+      if key not in DICTIONARY_FIELDS or original[key] == None:
+        modified.pop(key)
+    return modified
+
+  def is_equal(original, data):
+    retVal = (original == data) # TODO: More elaborate way of doing this
+    print (f'original: {original}')
+    print (f'new: {data}')
+    print (f'value: {retVal}')
+    return retVal
+
+  def new_and_deleted_dictionaries(previous, current):
+    dictionaries = []
+    currentCodes = [dictionary['code'] for dictionary in current]
+    previousCodes = [dictionary['code'] for dictionary in previous]
+    newCodes = list(set(currentCodes) - set(previousCodes))
+    deletedCodes = list(set(previousCodes) - set(currentCodes))
+    for newCode in newCodes:
+      dictionaries.append(DiffHelper.find_by_code(current, newCode))
+      currentCodes.remove(newCode)
+    for deletedCode in deletedCodes:
+      dictionary = DiffHelper.find_by_code(previous, deletedCode)
+      dictionaries.append({
+        'id': dictionary['id'],
+        'code': dictionary['code'],
+        'toBeDeleted': True
+        })
+      print ('deleted')
+      print(deletedCode)
+      print (currentCodes)
+      if deletedCode in currentCodes: currentCodes.remove(deletedCode)
+    return [currentCodes, dictionaries]
+
+  def find_by_code(dictionaries, code):
+    for dictionary in dictionaries:
+      if dictionary['code'] == code:
+        return dictionary
+
+  def changed_dictionaries(current, previous, codes):
+    dictionaries = []
+    for code in codes:
+      currentDictionary = DiffHelper.find_by_code(current, code)
+      previousDictionary = DiffHelper.find_by_code(previous, code)
+      previousDictionary = DiffHelper.sanitize_dict(previousDictionary)
+      if DiffHelper.is_equal(currentDictionary, previousDictionary):
+        print (f'the 2 dictionaries are equal {currentDictionary["code"]}')
+        continue
+
+      if not DiffHelper.is_equal(currentDictionary.get('fields'), previousDictionary.get('fields')) or not DiffHelper.is_equal(currentDictionary.get('lookups'), previousDictionary.get('lookups')):
+        dictionaries.append(currentDictionary)
+      else:
+        dictionaries.append({
+          'id': currentDictionary.get('id'),
+          'code': currentDictionary['code'],
+          'name':currentDictionary['name'],
+          'description':currentDictionary.get('description'),
+        })
+    return dictionaries
+  

--- a/datasets/diff_helper.py
+++ b/datasets/diff_helper.py
@@ -3,6 +3,12 @@ import os
 import json
 import sys
 
+DATASET_FIELDS = [
+  'name',
+  'workflow_key',
+  'visibility'
+]
+
 CATALOGUE_FIELDS = [
   'description',
   'creator',
@@ -24,6 +30,12 @@ DICTIONARY_FIELDS = [
 ]
 
 class DiffHelper:
+  def toplevel_diff(previous, current):
+    diff = {}
+    for field in DATASET_FIELDS:
+      if (field in current and previous[field] != current[field]): diff[field] = current[field]
+    return diff
+    
   def catalogue_diff(previous, current):
     diff = {}
     for field in CATALOGUE_FIELDS:
@@ -41,9 +53,7 @@ class DiffHelper:
 
     if DiffHelper.is_equal(original, data): return diff
     
-    if 'name' in data and original['name'] != data['name']:
-      diff['name'] = data['name']
-    
+    diff = DiffHelper.toplevel_diff(original, data)
     catalogueUpdates = DiffHelper.catalogue_diff(original['catalogue'], data['catalogue'])
     dictionaryUpdates = DiffHelper.dictionaries_diff(original['dictionaries'], data['dictionaries'])
     if catalogueUpdates: diff['catalogue'] = catalogueUpdates
@@ -60,9 +70,6 @@ class DiffHelper:
 
   def is_equal(original, data):
     retVal = (original == data) # TODO: More elaborate way of doing this
-    print (f'original: {original}')
-    print (f'new: {data}')
-    print (f'value: {retVal}')
     return retVal
 
   def new_and_deleted_dictionaries(previous, current):
@@ -81,9 +88,6 @@ class DiffHelper:
         'code': dictionary['code'],
         'toBeDeleted': True
         })
-      print ('deleted')
-      print(deletedCode)
-      print (currentCodes)
       if deletedCode in currentCodes: currentCodes.remove(deletedCode)
     return [currentCodes, dictionaries]
 
@@ -99,7 +103,6 @@ class DiffHelper:
       previousDictionary = DiffHelper.find_by_code(previous, code)
       previousDictionary = DiffHelper.sanitize_dict(previousDictionary)
       if DiffHelper.is_equal(currentDictionary, previousDictionary):
-        print (f'the 2 dictionaries are equal {currentDictionary["code"]}')
         continue
 
       if not DiffHelper.is_equal(currentDictionary.get('fields'), previousDictionary.get('fields')) or not DiffHelper.is_equal(currentDictionary.get('lookups'), previousDictionary.get('lookups')):

--- a/datasets/diff_helper.py
+++ b/datasets/diff_helper.py
@@ -69,7 +69,7 @@ class DiffHelper:
     return modified
 
   def is_equal(original, data):
-    retVal = (original == data) # TODO: More elaborate way of doing this
+    retVal = (original == data)
     return retVal
 
   def new_and_deleted_dictionaries(previous, current):

--- a/datasets/diff_helper.py
+++ b/datasets/diff_helper.py
@@ -51,7 +51,7 @@ class DiffHelper:
   def dataset_diff(original, data):
     diff = {}
 
-    if DiffHelper.is_equal(original, data): return diff
+    if original == data: return diff
     
     diff = DiffHelper.toplevel_diff(original, data)
     catalogueUpdates = DiffHelper.catalogue_diff(original['catalogue'], data['catalogue'])
@@ -67,10 +67,6 @@ class DiffHelper:
       if key not in DICTIONARY_FIELDS or original[key] == None:
         modified.pop(key)
     return modified
-
-  def is_equal(original, data):
-    retVal = (original == data)
-    return retVal
 
   def new_and_deleted_dictionaries(previous, current):
     dictionaries = []
@@ -102,10 +98,10 @@ class DiffHelper:
       currentDictionary = DiffHelper.find_by_code(current, code)
       previousDictionary = DiffHelper.find_by_code(previous, code)
       previousDictionary = DiffHelper.sanitize_dict(previousDictionary)
-      if DiffHelper.is_equal(currentDictionary, previousDictionary):
+      if currentDictionary == previousDictionary:
         continue
 
-      if not DiffHelper.is_equal(currentDictionary.get('fields'), previousDictionary.get('fields')) or not DiffHelper.is_equal(currentDictionary.get('lookups'), previousDictionary.get('lookups')):
+      if currentDictionary.get('fields') != previousDictionary.get('fields') or currentDictionary.get('lookups') != previousDictionary.get('lookups'):
         dictionaries.append(currentDictionary)
       else:
         dictionaries.append({

--- a/fair-api-datasets-create.py
+++ b/fair-api-datasets-create.py
@@ -1,86 +1,26 @@
-import requests
-import os
-import json
-import sys
 from datasets.diff_helper import DiffHelper
+from datasets.command_base import *
 
-if 'FAIR_API_TOKEN' not in os.environ:
-    print('Please add FAIR_API_TOKEN to the environment')
-    exit(1)
 
-if 'FAIR_API_ENDPOINT' not in os.environ:
-    print('Please add FAIR_API_ENDPOINT to the environment')
-    exit(1)
+def post_request(data):
+    print (f'\nPOST {dataset_url()} --data {json.dumps(data, indent=2)}')
 
-if len(sys.argv) < 2:
-    print(f'Usage: {sys.argv[0]} <path to dataset definition json file>')
-    exit(1)
+    if not DRY_RUN:
+        print('Sending request...')
+        r = requests.post(dataset_list_endpoint, headers=headers, json=data, verify=False)
+        if r.status_code != 201:
+            data = r.json()
+            print(f'Failed to create dataset: Status code: {r.status_code}, Error message: {data["error"]["message"]}')
+        else:
+            data = r.json()
     
-FAIR_API_TOKEN=os.environ['FAIR_API_TOKEN']
-FAIR_API_ENDPOINT=os.environ['FAIR_API_ENDPOINT']
-https = 'https://'
+            if len(data) != 1:
+                print(f'Created dataset: {data["code"]}')
+                print(f'View on the web at: {FAIR_URL}#/data/datasets/{data["code"]}')
+            else:
+                print(f'Expected 1 dataset in response - received {(data)}')
 
-if FAIR_API_ENDPOINT[:5] == 'https':
-    https = ''
-
-definition_file = sys.argv[1]
-if not os.path.isfile(definition_file):
-    print(f'Definition file not valid: {definition_file}')
-    exit(1)
-
-dataset_list_endpoint = f'{https}{FAIR_API_ENDPOINT}datasets'
-FAIR_URL = f'{https}{FAIR_API_ENDPOINT}'[:-4]
-
-print(f'API endpoint: {dataset_list_endpoint}')
-print(f'Posting definition: {definition_file}')
-
-headers = {
-    'Authorization': f'Bearer {FAIR_API_TOKEN}',
-    'Content-Type' : 'application/json'
-}
-
-def dataset_url():
-  return f'{https}{FAIR_API_ENDPOINT}datasets/'
-
-def patch_request(data):
-  dataset_code = data['catalogue']['id']
-
-  href = f'{https}{FAIR_API_ENDPOINT}datasets/{dataset_code}'
-  resp = requests.get(
-    href, headers=headers, verify=False
-  )
-  original = resp.json()
-
-  print (f'ORIGINAL {json.dumps(original, indent=2)}')
-  
-  diff = DiffHelper.dataset_diff(original, data)
-
-  print (f'PATCH {dataset_url()} --data {json.dumps(diff, indent=2)}')
-  # href = f'{https}{FAIR_API_ENDPOINT}datasets/{dataset_code}'
-  # resp = requests.patch(
-  #   href, headers=headers, json=data, verify=False
-  # )
-  # print('patched')
-  # print(resp.json())  
-
-with open(definition_file) as fh:
+with open(definition_file()) as fh:
     payload=fh.read()
     data=json.loads(payload)
-    print (f'POSTING {json.dumps(data, indent=2)}')
-
-    r = requests.post(dataset_list_endpoint, headers=headers, json=data, verify=False)
-    if r.status_code == 400 and r.json()["error"]["message"] == 'Dataset already exists':
-      print('already exists')
-      patch_request(data)
-    elif r.status_code != 201:
-        data = r.json()
-        print(f'Failed to create dataset: Status code: {r.status_code}, Error message: {data["error"]["message"]}')
-    else:
-        data = r.json()
-  
-        if len(data) != 1:
-            print(f'Created dataset: {data["code"]}')
-            print(f'View on the web at: {FAIR_URL}#/data/datasets/{data["code"]}')
-        else:
-            print(f'Expected 1 dataset in response - received {(data)}')
-           
+    post_request(data)

--- a/fair-api-datasets-create.py
+++ b/fair-api-datasets-create.py
@@ -3,6 +3,8 @@ import os
 import json
 import sys
 
+
+
 if 'FAIR_API_TOKEN' not in os.environ:
     print('Please add FAIR_API_TOKEN to the environment')
     exit(1)
@@ -14,7 +16,7 @@ if 'FAIR_API_ENDPOINT' not in os.environ:
 if len(sys.argv) < 2:
     print(f'Usage: {sys.argv[0]} <path to dataset definition json file>')
     exit(1)
-
+    
 FAIR_API_TOKEN=os.environ['FAIR_API_TOKEN']
 FAIR_API_ENDPOINT=os.environ['FAIR_API_ENDPOINT']
 https = 'https://'
@@ -38,13 +40,66 @@ headers = {
     'Content-Type' : 'application/json'
 }
 
+def is_equal(original, data):
+  original == data # TODO: More elaborate way of doing this
 
+def catalogue_diff(original, data):
+  pass
+
+def dictionaries_diff(original, data):
+  pass
+
+def dataset_diff(original, data):
+  diff = {}
+
+  if is_equal(original, data): return diff
+  
+  if 'name' in data and original['name'] != data['name']:
+    diff['name'] = data['name']
+  
+  catalogueUpdates = catalogue_diff(original.catalogue, data.catalogue)
+  dictionaryUpdates = dictionaries_diff(original.dictionaries, data.dictionaries)
+  if catalogueUpdates: diff['catalogues'] = catalogueUpdates
+  if dictionaryUpdates: diff['dictionaries'] = dictionaryUpdates
+  
+  return diff
+
+def patch_request(payload):
+  data = json.loads(payload)
+  dataset_code = data['catalogue']['id']
+
+  href = f'{https}{FAIR_API_ENDPOINT}datasets/{dataset_code}'
+  resp = requests.get(
+    href, headers=headers, verify=False
+  )
+  original = resp.json()
+
+  print (f'ORIGINAL {json.dumps(original, indent=2)}')
+  
+  diff = dataset_diff(original, data)
+
+  data['catalogue'].pop('id')
+  data['catalogue'].pop('title')
+  data['catalogue'].pop('issued')
+  data['catalogue'].pop('language')
+  data['catalogue'].pop('accessRights')
+
+  print (f'PATCHING {json.dumps(diff, indent=2)}')
+  # href = f'{https}{FAIR_API_ENDPOINT}datasets/{dataset_code}'
+  # resp = requests.patch(
+  #   href, headers=headers, json=data, verify=False
+  # )
+  # print('patched')
+  # print(resp.json())  
 
 with open(definition_file) as fh:
     payload=fh.read()
-            
-    r = requests.post(dataset_list_endpoint, headers=headers, json=json.loads(payload))
-    if r.status_code != 201:
+
+    r = requests.post(dataset_list_endpoint, headers=headers, json=json.loads(payload), verify=False)
+    if r.status_code == 400 and r.json()["error"]["message"] == 'Dataset already exists':
+      print('already exists')
+      patch_request(payload)
+    elif r.status_code != 201:
         data = r.json()
         print(f'Failed to create dataset: Status code: {r.status_code}, Error message: {data["error"]["message"]}')
     else:

--- a/fair-api-datasets-create.py
+++ b/fair-api-datasets-create.py
@@ -2,19 +2,7 @@ import requests
 import os
 import json
 import sys
-
-
-CATALOGUE_FIELDS = [
-  'description',
-  'creator',
-  'contactPoint',
-  'publisher',
-  'license',
-  'versionInfo',
-  'keyword',
-  'identifier',
-  'rights',
-]
+from datasets.diff_helper import DiffHelper
 
 if 'FAIR_API_TOKEN' not in os.environ:
     print('Please add FAIR_API_TOKEN to the environment')
@@ -51,32 +39,8 @@ headers = {
     'Content-Type' : 'application/json'
 }
 
-def is_equal(original, data):
-  original == data # TODO: More elaborate way of doing this
-
-def catalogue_diff(previous, current):
-  diff = {}
-  for field in CATALOGUE_FIELDS:
-    if (field in current and previous[field] != current[field]): diff[field] = current[field]
-  return diff
-
-def dictionaries_diff(original, data):
-  pass
-
-def dataset_diff(original, data):
-  diff = {}
-
-  if is_equal(original, data): return diff
-  
-  if 'name' in data and original['name'] != data['name']:
-    diff['name'] = data['name']
-  
-  catalogueUpdates = catalogue_diff(original['catalogue'], data['catalogue'])
-  dictionaryUpdates = dictionaries_diff(original['dictionaries'], data['dictionaries'])
-  if catalogueUpdates: diff['catalogue'] = catalogueUpdates
-  if dictionaryUpdates: diff['dictionaries'] = dictionaryUpdates
-  
-  return diff
+def dataset_url():
+  return f'{https}{FAIR_API_ENDPOINT}datasets/'
 
 def patch_request(data):
   dataset_code = data['catalogue']['id']
@@ -89,15 +53,9 @@ def patch_request(data):
 
   print (f'ORIGINAL {json.dumps(original, indent=2)}')
   
-  diff = dataset_diff(original, data)
+  diff = DiffHelper.dataset_diff(original, data)
 
-  data['catalogue'].pop('id')
-  data['catalogue'].pop('title')
-  data['catalogue'].pop('issued')
-  data['catalogue'].pop('language')
-  data['catalogue'].pop('accessRights')
-
-  print (f'PATCHING {json.dumps(diff, indent=2)}')
+  print (f'PATCH {dataset_url()} --data {json.dumps(diff, indent=2)}')
   # href = f'{https}{FAIR_API_ENDPOINT}datasets/{dataset_code}'
   # resp = requests.patch(
   #   href, headers=headers, json=data, verify=False

--- a/fair-api-datasets-update.py
+++ b/fair-api-datasets-update.py
@@ -1,0 +1,39 @@
+from datasets.diff_helper import DiffHelper
+from datasets.command_base import *
+
+
+def get_request(dataset_code):
+    href = dataset_url(dataset_code)
+    resp = requests.get(
+        href, headers=headers, verify=False
+    )
+    if resp.status_code != 200:
+        data = resp.json()
+        print(f'\nFailed to get dataset: Status code: {resp.status_code}, Error message: {data["error"]["message"]}')
+        exit(1)
+    return resp
+
+def patch_request(data):
+    dataset_code = data['catalogue']['id']
+    resp = get_request(dataset_code)
+    original = resp.json()
+    diff = DiffHelper.dataset_diff(original, data)
+    print (f'\nPATCH {dataset_url(dataset_code)} --data {json.dumps(diff, indent=2)}')
+    if not DRY_RUN:
+        print('Sending request...')
+        r = requests.patch(dataset_url(dataset_code), headers=headers, json=diff, verify=False)
+        if r.status_code != 200:
+            data = r.json()
+            print(f'Failed to patch dataset: Status code: {r.status_code}, Error message: {data["error"]["message"]}')
+        else:
+            data = r.json()    
+            if len(data) != 1:
+                print(f'Patched dataset: {data["code"]}')
+                print(f'View on the web at: {FAIR_URL}#/data/datasets/{data["code"]}')
+            else:
+                print(f'Expected 1 dataset in response - received {(data)}')
+
+with open(definition_file()) as fh:
+    payload=fh.read()
+    data=json.loads(payload)
+    patch_request(data)


### PR DESCRIPTION
This adds a command to demonstrate update cycle of datasets `fair-api-datasets-update.py`. Adds documentation to describe how create / update cycle should work.

It also adds a --dry-run option to `fair-api-datasets-create.py` and `fair-api-datasets-update.py` commands to allow for experimentation.